### PR TITLE
Update dependencies installation command to support killall

### DIFF
--- a/docs/getting-started/linux_dependencies.md
+++ b/docs/getting-started/linux_dependencies.md
@@ -29,7 +29,7 @@ Finally proceed to [instructions after dependencies](#after-dependencies)
 
 3. Install following dependencies:
    ```
-   sudo apt-get install erlang libncurses5-dev libssl-dev unixodbc-dev g++ git erlang-base-hipe make
+   sudo apt-get install erlang libncurses5-dev libssl-dev unixodbc-dev g++ git erlang-base-hipe make psmisc
    ```
 
 ## For ArchLinux


### PR DESCRIPTION
Added "psmisc" package just in case "killall" command is missing:

https://bytefreaks.net/gnulinux/bash/bash-killall-command-not-found-a-solution