### PR TITLE
Correct self-run wallet instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Amoveo main net was launched at 11:00 AM GMT on March 2, 2018.
 ## Light node
 Simply visit [this webpage](http://159.65.120.84:8080/wallet.html) to participate in Amoveo, no installation necessary.
 
-You can also download the javascript light node to ensure you have the secure version, and to be able to run in cold storage. To use the javascript light node open this file with your browser: `apps/amoveo_http/priv/external_web/wallet.html`
+You can also download the javascript light node to ensure you have the secure version, and to be able to run in cold storage. To use the javascript light node start amoveo with `make prod-go` and visit: `http://127.0.0.1:8080/wallet.html`
 
 This light node downloads headers and verifies the proof of work.
 It verifies the merkle proofs for all blockchain state you download to ensure security equivalent to a full node, provided you wait for enough confirmations.


### PR DESCRIPTION
Running locally breaks https://github.com/icook/amoveo/blob/master/apps/amoveo_http/priv/external_web/server.js#L13 (there's no colon in a local URL), making it impossible to connect to any node since the input box never displays.