### PR TITLE
Fixing brokenlink build_intro and descriptive text

### DIFF
--- a/docs/getting-started/build_intro.md
+++ b/docs/getting-started/build_intro.md
@@ -142,8 +142,7 @@ You can also clean all 3 at once
 
 
 ### Blockchain Commands
-
-[Read about the commands in depth in the docs](docs/api/commands.md)
+[Read the blockchain terminal interface commands docs](../api/commands.md) for a deeper dive into using the blockchain terminal commands to interface with the blockchain basics, accounts, lookup history, accounts, lookup history, channels, oracles, markets and other interesting functionality.
 
 
 #### Sync with the network


### PR DESCRIPTION
Adding more descriptive text about what is in the blockchain interface commands documentation, and fixing the broken link.