### PR TITLE
Add retry to test

### DIFF
--- a/tests/get_request.py
+++ b/tests/get_request.py
@@ -30,6 +30,13 @@ def request_ext(node, action, args, seconds_to_sleep=0):
 def request_helper(url, action, args, seconds_to_sleep):
     d2 = json.dumps(byteify([action] + args))
     req = urllib2.Request(url=url, data = d2)
-    f = urllib2.urlopen(req)
+    f = urlopen_with_retry(req)
     sleep(seconds_to_sleep)
     return f.read()
+def urlopen_with_retry(req, max_retry=2):
+    for _ in range(max_retry):
+        try:
+            return urllib2.urlopen(req)
+        except Exception:
+            sleep(5)
+    raise RuntimeError('Request failed {} times.'.format(max_retry))


### PR DESCRIPTION
Ref #172 

If a request fails, wait five seconds and retry one more time. If it fails again raise error.
Tested in my environment and spurious errors due to race conditions were eliminated.