### PR TITLE
Limit EPMD to only accept local connections

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ SWAGGER = apps/amoveo_http/src/swagger
 SWTEMP := $(shell mktemp -d 2>/dev/null || mktemp -d -t 'mytmpdir')
 LOCAL = ./_build/local/rel
 
+export ERL_EPMD_ADDRESS = 127.0.0.1
+
 kill:
 	@echo "Kill all beam processes only from this directory tree"
 	$(shell pkill -9 -f ".*/beam.*-boot `pwd`" || true)
@@ -136,6 +138,7 @@ build: $$(KIND)
 
 go: $$(KIND)
 	@./_build/$(KIND)/$(CORE) start
+
 
 stop: $$(KIND)
 	@./_build/$(KIND)/$(CORE) stop &


### PR DESCRIPTION
I believe this will make EPMD only listen for local connections, making it harder to connect to an Amoveo node from an outside server