### PR TITLE
Fix `oracle_bets` call

### DIFF
--- a/apps/amoveo_http/src/ext_handler.erl
+++ b/apps/amoveo_http/src/ext_handler.erl
@@ -272,7 +272,7 @@ doit({oracle_bets, OID}) ->
     Trees = B#block.trees,
     Oracles = trees:oracles(Trees),
     {_, Oracle, _} = oracles:get(OID, Oracles),
-    orders:get_all(Oracle#oracle.orders);%This does multiple hard drive reads. It could be a security vulnerability. Maybe we should keep copies of this data in ram, for recent blocks.
+    orders:all(Oracle#oracle.orders);%This does multiple hard drive reads. It could be a security vulnerability. Maybe we should keep copies of this data in ram, for recent blocks.
 doit({market_data, OID}) ->
     %{ok, OB} = order_book:data(base64:decode(OID)),
     {ok, OB} = order_book:data(OID),


### PR DESCRIPTION
Now it uses `orders:get_all` call which is absent.

Fix it changing to `orders:all` call.