### PR TITLE
Expose ewah method in API

### DIFF
--- a/apps/amoveo_http/src/ext_handler.erl
+++ b/apps/amoveo_http/src/ext_handler.erl
@@ -94,6 +94,9 @@ doit({headers, _H}) ->
 doit({headers, Many, N}) -> 
     X = many_headers(Many, N),
     {ok, X};
+doit({ewah, Start, End}) ->
+    X = api:ewah(Start, End),
+    {ok, X};
 doit({header}) -> {ok, headers:top()};
 doit({peers}) ->
     P = peers:all(),


### PR DESCRIPTION
Simple call to read ewah by HTTP API.

Useful for analytics purposes.